### PR TITLE
Added support for collapsing folders for paths with same prefix.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -2,6 +2,7 @@ const raml = require('raml-1-parser'),
   _ = require('lodash'),
   SDK = require('postman-collection'),
   helper = require('./helper.js'),
+  { Node, Trie } = require('./trie.js'),
 
   // This is the default collection name if one can't be inferred from the RAML 1.0 spec
   COLLECTION_NAME = 'Converted from RAML 1.0';
@@ -39,6 +40,7 @@ var converter = {
         ramlAPI = raml.parseRAMLSync(ramlString),
         ramlJSON = ramlAPI.toJSON(),
         convertedBaseUrl,
+        trie,
         info = {
           title: _.get(ramlJSON, 'title', COLLECTION_NAME),
           documentation: _.get(ramlJSON, 'documentation', ''),
@@ -77,8 +79,17 @@ var converter = {
         type: 'string'
       });
 
-      ramlJSON.resources && ramlJSON.resources.forEach(function (resource) {
-        collection.items.add(helper.convertResources(convertedBaseUrl, resource, RootParameters));
+      // creating a root node for the trie (serves as the root dir)
+      trie = new Trie(new Node({ name: '/' }));
+
+      // Generate/add trie nodes from raml resources to trie
+      helper.generateTrieFromResources(trie, ramlJSON.resources, RootParameters);
+
+      // Add each resource and it's childrens to postman collection
+      _.forEach(trie.root.children, (child) => {
+        collection.items.add(
+          helper.convertChildToItemGroup(convertedBaseUrl, child, RootParameters)
+        );
       });
 
       return cb(null, {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,5 +1,6 @@
 const SDK = require('postman-collection'),
   _ = require('lodash'),
+  Node = require('./trie.js').Node,
   jsf = require('json-schema-faker');
 
 jsf.option({
@@ -369,7 +370,7 @@ helper = {
 
   /**
   *
-  * Used to convert raml method json to a postman sdk item object
+  * Used to convert raml method to a postman sdk item object
   *
   * @param {Object} method - raml method in json format
   * @param {String} url - url of the raml request
@@ -378,7 +379,7 @@ helper = {
   *
   * @returns {Object} item - postman sdk item object
   */
-  convertMethod: function(method, url, globalParameters, pathVariables) {
+  convertRequestToItem: function(method, url, globalParameters, pathVariables) {
     let item = new SDK.Item(),
       request = new SDK.Request(),
       requestUrl = new SDK.Url(),
@@ -462,41 +463,206 @@ helper = {
   },
 
   /**
-  *
-  * Used to convert raml resource json to a postman sdk ItemGroup object
-  *
-  * @param {string} baseUrl - base url string
-  * @param {String} res - raml resource json
-  * @param {Object} globalParameters - Object with parameters given at root level of raml spec
-  * @param {Array} pathVariables - Array with all path variables and it's value and decription.
-  *
-  * @returns {Object} folder - postman sdk ItemGroup object
-  */
-  convertResources: function(baseUrl, res, globalParameters, pathVariables = []) {
-    var folder = new SDK.ItemGroup(),
+   *
+   * convert childItem to Postman itemGroup if requestCount(no of requests inside childitem) > 1
+   * or it is collapsible folder otherwise return postman request
+   *
+   * @param {string} baseUrl - base url string
+   * @param {Object} child - child object can be of type itemGroup or request
+   * @param {Object} globalParameters - Object with parameters given at root level of raml spec
+   * @param {Array} pathVariables - Array with all path variables in relative baseUrl and it's value and decription.
+   * @returns {*} Postman itemGroup or request
+   * @no-unit-test
+   */
+  convertChildToItemGroup: function(baseUrl, child, globalParameters, pathVariables = []) {
+    var resource = child,
+      itemGroup,
+      subChild,
+      i,
       url,
-      convertedUrlAndVars;
+      // used to store url after path variables of url is resolved
+      convertedBaseUrl = _.cloneDeepWith(baseUrl),
+      displayName = _.get(resource, 'resourceInfo.displayName', resource.name),
+      relativeUrl = _.get(resource, 'resourceInfo.relativeUri', ''),
+      requestCount,
+      convertedUrlAndVars = helper.addParametersToUrl(
+        _.get(resource, 'resourceInfo.relativeUri', ''),
+        _.get(resource, 'resourceInfo.uriParameters', []),
+        globalParameters.types
+      );
 
-    convertedUrlAndVars = helper.addParametersToUrl(res.relativeUri, res.uriParameters, globalParameters.types);
     url = baseUrl.value + convertedUrlAndVars.url;
     pathVariables = _.concat(pathVariables, convertedUrlAndVars.variables);
+    // replace current url with resolved path variable one
+    convertedBaseUrl.value = url;
 
-    baseUrl.value = url;
-    res.displayName && (folder.name = res.displayName);
-    res.description && (folder.description = res.description);
-    res.is && res.methods.forEach(function (method) {
-      method.is = res.is;
+    // Add resource traits to it's child methods and resources
+    if (_.has(resource, 'resourceInfo.is')) {
+      _.forEach(resource.requests, (request) => {
+        request.method.is = _.concat(
+          _.isArray(request.method.is) ? request.method.is : [],
+          _.get(resource, 'resourceInfo.is', [])
+        );
+      });
+
+      _.forEach(resource.children, (child) => {
+        child.resourceInfo.is = _.concat(
+          _.isArray(child.resourceInfo.is) ? child.resourceInfo.is : [],
+          _.get(resource, 'resourceInfo.is', [])
+        );
+      });
+    }
+
+    // 3 options:
+
+    // 1. folder with more than one request in its subtree or not collapsible
+    if (resource.requestCount > 1 || !resource.collapsible) {
+      // only return a Postman folder if this folder has>1 children in its subtree or it's not collapsible
+      // otherwise we can end up with 10 levels of unwanted folders with 1 request in the end
+      itemGroup = new SDK.ItemGroup({
+        name: displayName === relativeUrl ? resource.name : displayName,
+        description: _.get(resource, 'resourceInfo.description', '')
+      });
+
+      // If a folder has only one child and can be collapsed then we collapse the child folder
+      // with parent folder.
+      if (resource.childCount === 1 && resource.collapsible) {
+        let subChild = Object.keys(resource.children)[0],
+          resourceSubChild = resource.children[subChild];
+
+        resourceSubChild.name = resource.name + '/' + resourceSubChild.name;
+
+        return this.convertChildToItemGroup(convertedBaseUrl, resourceSubChild, globalParameters, pathVariables);
+      }
+      // recurse over child leaf nodes
+      // and add as children to this folder
+      for (i = 0, requestCount = resource.requests.length; i < requestCount; i++) {
+        itemGroup.items.add(
+          this.convertRequestToItem(resource.requests[i].method, url, globalParameters, pathVariables)
+        );
+      }
+
+      // recurse over child folders
+      // and add as child folders to this folder
+      for (subChild in resource.children) {
+        if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount > 0) {
+          itemGroup.items.add(
+            this.convertChildToItemGroup(convertedBaseUrl, resource.children[subChild], globalParameters, pathVariables)
+          );
+        }
+      }
+
+      return itemGroup;
+    }
+
+    // 2. it has only 1 direct request of its own
+    if (resource.requests.length === 1) {
+      return this.convertRequestToItem(resource.requests[0].method, url, globalParameters, pathVariables);
+    }
+
+    // 3. it's a folder that has no child request
+    // but one request somewhere in its child folders
+    for (subChild in resource.children) {
+      if (resource.children.hasOwnProperty(subChild) && resource.children[subChild].requestCount === 1) {
+        if (displayName === relativeUrl) {
+          // Change resource name to append parent folder name in child's folder name
+          resource.children[subChild].name = resource.name +
+            _.get(resource.children[subChild], 'resourceInfo.displayName');
+        }
+
+        return this.convertChildToItemGroup(
+          convertedBaseUrl,
+          resource.children[subChild],
+          globalParameters,
+          pathVariables
+        );
+      }
+    }
+  },
+
+  /**
+   *
+   * Generates a Trie structure from the resources object of the RAML 1.0 specification. (Recursive)
+   *
+   * @param {Trie} trie - trie data structure
+   * @param {Object} resources - raml resources
+   * @param {Object} globalParameters - some root level parameters (i.e. baseUrl, securitySchema etc)
+   * @returns {void}
+   */
+  generateTrieFromResources: function (trie, resources, globalParameters) {
+    var currentPath = '',
+      pathLength,
+      currentNode,
+      isCollapsible,
+      path,
+      i;
+
+    _.forEach(resources, (resource) => {
+
+      // resource path of current resource relative to baseUri
+      path = _.get(resource, 'absoluteUri', '').replace(globalParameters.baseUri, '');
+
+      // discard the leading slash, if it exists
+      if (path[0] === '/') {
+        path = path.substring(1);
+      }
+
+      // split the path into indiv. segments for trie generation
+      // unless path it the root endpoint
+      currentPath = path === '' ? ['(root)'] : path.split('/').filter((pathItem) => {
+        // remove any empty pathItems that might have cropped in
+        // due to trailing or double '/' characters
+        return pathItem !== '';
+      });
+
+      // If resource has displayName or description of it's own than don't collapse folders
+      isCollapsible = _.get(resource, 'displayName', null) === resource.relativeUri && !_.has(resource, 'description');
+      pathLength = currentPath.length;
+      currentNode = trie.root;
+
+      // adding children for the nodes in the trie
+      // start at the top-level and do a DFS
+      for (i = 0; i < pathLength; i++) {
+        if (!currentNode.children[currentPath[i]]) {
+          // if the currentPath doesn't already exist at this node, add it as a folder
+          currentNode.addChildren(currentPath[i], new Node({
+            name: currentPath[i],
+            // set resourse specific properties only for last path of resource
+            resourceInfo: (i === pathLength - 1) ? _.omit(resource, ['resources', 'methods', '__METADATA__']) : {},
+            collapsible: (i === pathLength - 1) && isCollapsible,
+            requestCount: 0,
+            requests: [],
+            children: {},
+            type: 'item-group',
+            childCount: 0
+          }));
+
+          // We are keeping the count children in a folder which can be a request or folder
+          // For ex- In case of /pets/a/b, pets has 1 childCount (i.e a)
+          currentNode.childCount += 1;
+        }
+        // requestCount increment for the node we just added
+        currentNode.children[currentPath[i]].requestCount += _.get(resource, 'methods.length', 0);
+        currentNode = currentNode.children[currentPath[i]];
+      }
+
+      // add methods to node
+      _.each(resource.methods, (method) => {
+        currentNode.addMethod({
+          name: method.method,
+          method: method,
+          type: 'item'
+        });
+        currentNode.childCount += 1;
+      });
+
+      // Recursive strategy needed as nested resources are allowed in RAML
+      if (resource.resources) {
+        helper.generateTrieFromResources(trie, resource.resources, globalParameters);
+      }
     });
 
-    res.methods && res.methods.forEach(function (method) {
-      folder.items.add(helper.convertMethod(method, url, globalParameters, pathVariables));
-    });
-
-    res.resources && res.resources.forEach(function (resource) {
-      folder.items.add(helper.convertResources(baseUrl, resource, globalParameters, pathVariables));
-    });
-
-    return folder;
+    return null;
   }
 };
 

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -1,0 +1,47 @@
+/**
+ * Class for the node of the tree containing the folders
+ * @param {object} options - Contains details about the folder/collection node
+ * @returns {void}
+ */
+function Node (options) {
+  // human-readable name
+  this.name = options ? options.name : '/';
+
+  // description of node (Needed as we have resource node specific info) (for folder in postman collection)
+  this.resourceInfo = options ? options.resourceInfo : {};
+
+  // Represents whether this node is collapsible or not (can it be merged to parent)
+  this.collapsible = options ? options.collapsible : true;
+
+  // number of requests in the sub-trie of this node
+  this.requestCount = options ? options.requestCount : 0;
+
+  this.type = options ? options.type : 'item';
+
+  // stores all direct folder descendants of this node
+  this.children = {};
+
+  // number of folders in the sub-trie of this node
+  this.childCount = 0;
+
+  this.requests = []; // request will always be an array of objects
+
+  this.addChildren = function (child, value) {
+    this.children[child] = value;
+  };
+
+  this.addMethod = function (method) {
+    this.requests.push(method);
+  };
+}
+
+class Trie {
+  constructor(node) {
+    this.root = node;
+  }
+}
+
+module.exports = {
+  Trie: Trie,
+  Node: Node
+};

--- a/test/fixtures/valid-raml/ramlSpecBasicCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecBasicCollection.json
@@ -1,103 +1,101 @@
 {
   "item": [
     {
+      "name": "users/search",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
       "item": [
         {
-          "item": [
+          "response": [
             {
-              "response": [
+              "header": [
                 {
-                  "header": [
-                    {
-                      "key": "Location",
-                      "value": "/invoices/45612"
-                    },
-                    {
-                      "key": "Header",
-                      "value": "Bangalore"
-                    }
-                  ],
-                  "cookie": [],
-                  "code": "201",
-                  "name": "201",
-                  "body": "{\"groupName\":\"groupName example\",\"deptCode\":12345}"
+                  "key": "Location",
+                  "value": "/invoices/45612"
+                },
+                {
+                  "key": "Header",
+                  "value": "Bangalore"
                 }
               ],
-              "event": [],
-              "name": "/users/search",
-              "request": {
-                "url": {
-                  "path": [
-                    "users",
-                    "search"
-                  ],
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "query": [],
-                  "variables": []
-                },
-                "method": "GET",
-                "auth": {
-                  "type": "basic",
-                  "description": {
-                    "content": "This is basic security scheme",
-                    "type": "text/plain"
-                  }
-                }
-              }
-            },
-            {
-              "response": [],
-              "event": [],
-              "name": "/users/search",
-              "request": {
-                "url": {
-                  "path": [
-                    "users",
-                    "search"
-                  ],
-                  "host": [
-                    "{{baseUrl}}"
-                  ],
-                  "query": [],
-                  "variables": []
-                },
-                "header": [
-                  {
-                    "key": "Content-Type",
-                    "value": "application/json"
-                  },
-                  {
-                    "key": "myHeader",
-                    "value": "headerExample"
-                  },
-                  {
-                    "key": "SomeOtherHeader",
-                    "value": "OtherExample"
-                  }
-                ],
-                "method": "POST",
-                "body": {
-                  "mode": "raw",
-                  "raw": "{\"firstname\":\"someName\",\"lastname\":\"someLastName\",\"age\":10}"
-                },
-                "auth": {
-                  "type": "basic",
-                  "description": {
-                    "content": "This is basic security scheme",
-                    "type": "text/plain"
-                  }
-                }
-              }
+              "cookie": [],
+              "code": "201",
+              "name": "201",
+              "body": "{\"groupName\":\"groupName example\",\"deptCode\":12345}"
             }
           ],
           "event": [],
-          "name": "/search"
+          "name": "/users/search",
+          "request": {
+            "url": {
+              "path": [
+                "users",
+                "search"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "method": "GET",
+            "auth": {
+              "type": "basic",
+              "description": {
+                "content": "This is basic security scheme",
+                "type": "text/plain"
+              }
+            }
+          }
+        },
+        {
+          "response": [],
+          "event": [],
+          "name": "/users/search",
+          "request": {
+            "url": {
+              "path": [
+                "users",
+                "search"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "myHeader",
+                "value": "headerExample"
+              },
+              {
+                "key": "SomeOtherHeader",
+                "value": "OtherExample"
+              }
+            ],
+            "method": "POST",
+            "body": {
+              "mode": "raw",
+              "raw": "{\"firstname\":\"someName\",\"lastname\":\"someLastName\",\"age\":10}"
+            },
+            "auth": {
+              "type": "basic",
+              "description": {
+                "content": "This is basic security scheme",
+                "type": "text/plain"
+              }
+            }
+          }
         }
       ],
-      "event": [],
-      "name": "/users"
+      "event": []
     }
   ],
   "event": [],

--- a/test/fixtures/valid-raml/ramlSpecExamplesCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecExamplesCollection.json
@@ -1,12 +1,27 @@
 {
   "item": [
     {
+      "name": "organization",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
       "item": [
         {
           "response": [],
           "event": [],
+          "name": "/organization",
           "request": {
-            "url": "{{baseUrl}}/organization",
+            "url": {
+              "path": [
+                "organization"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
             "header": [
               {
                 "key": "Content-Type",
@@ -18,7 +33,7 @@
                 "description": "the identifier for the user who posts a new organization"
               }
             ],
-            "method": "post",
+            "method": "POST",
             "body": {
               "mode": "raw",
               "raw": "{\"name\":\"Doe Enterprise\",\"value\":\"Silver\"}"
@@ -36,22 +51,31 @@
             }
           ],
           "event": [],
-          "description": "Returns an organization entity.",
+          "name": "/organization",
           "request": {
-            "url": "{{baseUrl}}/organization",
-            "method": "get"
+            "url": {
+              "path": [
+                "organization"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "method": "GET",
+            "description": "Returns an organization entity."
           }
         }
       ],
-      "event": [],
-      "name": "/organization"
+      "event": []
     }
   ],
   "event": [],
   "variable": [
     {
-      "type": "any",
-      "key": "baseUrl"
+      "type": "string",
+      "value": ""
     }
   ],
   "info": {

--- a/test/fixtures/valid-raml/ramlSpecFolderStructure.raml
+++ b/test/fixtures/valid-raml/ramlSpecFolderStructure.raml
@@ -1,0 +1,28 @@
+#%RAML 1.0
+title: Animals and Birds
+mediaType: application/json
+description: Will check for folder structure (Made from trie)
+version: v3
+baseUri: https://animal.birds.tech/{version}
+/:
+  get:
+    displayName: GET Request at root 
+/animal/dog:
+  post:
+    displayName: Display name for POST /animal/dog
+/animal/cat:
+  put:
+    displayName: Display name for PUT /animal/dog
+/mammal:
+  /dog:
+    /bulldog:
+      description: Folder will be made as this resource has description. With name mammal/dog/bulldog as no displayName is defined.
+      get:
+        displayName: Display name for GET mammal/dog/bulldog
+        description: This is bulldog
+/birds:
+  displayName: This is Birds.
+  /parrot:
+    description: Will not be collapsed with /birds as there is description present.
+    get:
+      displayName: JUST DO IT.

--- a/test/fixtures/valid-raml/ramlSpecFolderStructureCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecFolderStructureCollection.json
@@ -1,0 +1,161 @@
+{
+  "item": [
+    {
+      "response": [],
+      "event": [],
+      "name": "GET Request at root",
+      "request": {
+        "url": {
+          "path": [
+            ""
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variables": []
+        },
+        "method": "GET"
+      }
+    },
+    {
+      "name": "animal",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "response": [],
+          "event": [],
+          "name": "Display name for POST /animal/dog",
+          "request": {
+            "url": {
+              "path": [
+                "animal",
+                "dog"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "method": "POST"
+          }
+        },
+        {
+          "response": [],
+          "event": [],
+          "name": "Display name for PUT /animal/dog",
+          "request": {
+            "url": {
+              "path": [
+                "animal",
+                "cat"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "method": "PUT"
+          }
+        }
+      ],
+      "event": []
+    },
+    {
+      "name": "mammal/dog/bulldog",
+      "description": {
+        "content": "Folder will be made as this resource has description. With name mammal/dog/bulldog as no displayName is defined.",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "response": [],
+          "event": [],
+          "name": "Display name for GET mammal/dog/bulldog",
+          "request": {
+            "url": {
+              "path": [
+                "mammal",
+                "dog",
+                "bulldog"
+              ],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "query": [],
+              "variables": []
+            },
+            "method": "GET",
+            "description": "This is bulldog"
+          }
+        }
+      ],
+      "event": []
+    },
+    {
+      "name": "This is Birds.",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
+      "item": [
+        {
+          "name": "parrot",
+          "description": {
+            "content": "Will not be collapsed with /birds as there is description present.",
+            "type": "text/plain"
+          },
+          "item": [
+            {
+              "response": [],
+              "event": [],
+              "name": "JUST DO IT.",
+              "request": {
+                "url": {
+                  "path": [
+                    "birds",
+                    "parrot"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variables": []
+                },
+                "method": "GET"
+              }
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "description": {
+        "content": "This is version of API schema.",
+        "type": "text/plain"
+      },
+      "type": "any",
+      "value": "v3"
+    },
+    {
+      "type": "string",
+      "value": "https://animal.birds.tech/{{version}}"
+    }
+  ],
+  "info": {
+    "name": "Animals and Birds",
+    "version": "v3",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Will check for folder structure (Made from trie)"
+  }
+}

--- a/test/fixtures/valid-raml/ramlSpecNameAndDescCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecNameAndDescCollection.json
@@ -1,6 +1,11 @@
 {
   "item": [
     {
+      "name": "Folder named /users",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
       "item": [
         {
           "response": [],
@@ -22,10 +27,14 @@
           }
         }
       ],
-      "event": [],
-      "name": "Folder named /users"
+      "event": []
     },
     {
+      "name": "teams",
+      "description": {
+        "content": "Description of Folder named /teams",
+        "type": "text/plain"
+      },
       "item": [
         {
           "response": [],
@@ -34,7 +43,6 @@
           "request": {
             "url": {
               "path": [
-                "users",
                 "teams"
               ],
               "host": [
@@ -47,9 +55,7 @@
           }
         }
       ],
-      "event": [],
-      "name": "/teams",
-      "description": "Description of Folder named /teams"
+      "event": []
     }
   ],
   "event": [],

--- a/test/fixtures/valid-raml/ramlSpecTraitsCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecTraitsCollection.json
@@ -1,37 +1,42 @@
 {
   "item": [
     {
-      "item": [
-        {
-          "response": [],
-          "event": [],
-          "description": "The HTTP interaction will look like\n\nGET /users HTTP/1.1\nX-Dept: 18-FINANCE\nX-Dept: 200-MISC\nX-Tracker: gfr456d03ygh38s2\n",
-          "request": {
-            "url": "{{baseUrl}}/users",
-            "header": [
-              {
-                "key": "X-Dept",
-                "value": "",
-                "description": "A department code to be charged.\nMultiple of such headers are allowed.\n"
-              },
-              {
-                "key": "X-Tracker",
-                "value": "gfr456d03ygh38s2"
-              }
-            ],
-            "method": "get"
-          }
-        }
-      ],
+      "response": [],
       "event": [],
-      "name": "/users"
+      "name": "/users",
+      "request": {
+        "url": {
+          "path": [
+            "users"
+          ],
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "query": [],
+          "variables": []
+        },
+        "header": [
+          {
+            "key": "X-Dept",
+            "value": "",
+            "description": "A department code to be charged.\nMultiple of such headers are allowed.\n"
+          },
+          {
+            "key": "X-Tracker",
+            "value": "abcdefghijklmnop",
+            "description": "A code to track API calls end to end"
+          }
+        ],
+        "method": "GET",
+        "description": "The HTTP interaction will look like\n\nGET /users HTTP/1.1\nX-Dept: 18-FINANCE\nX-Dept: 200-MISC\nX-Tracker: gfr456d03ygh38s2\n"
+      }
     }
   ],
   "event": [],
   "variable": [
     {
-      "type": "any",
-      "key": "baseUrl"
+      "type": "string",
+      "value": ""
     }
   ],
   "info": {

--- a/test/fixtures/valid-raml/ramlSpecTypesCollection.json
+++ b/test/fixtures/valid-raml/ramlSpecTypesCollection.json
@@ -1,111 +1,125 @@
 {
   "item": [
     {
+      "name": "organization",
+      "description": {
+        "content": "",
+        "type": "text/plain"
+      },
       "item": [
         {
-          "response": [],
-          "event": [],
-          "name": "/organization/:uriParam1:uriParam2",
-          "request": {
-            "url": {
-              "path": [
-                "organization",
-                ":uriParam1:uriParam2"
-              ],
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "query": [],
-              "variables": [
-                {
-                  "key": "uriParam1",
-                  "value": "",
-                  "description": ""
-                },
-                {
-                  "key": "uriParam2",
-                  "value": "example",
-                  "description": ""
-                }
-              ]
-            },
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              },
-              {
-                "key": "Header1",
-                "value": "2016-02-28T16:41:41.090Z",
-                "disabled": true
-              },
-              {
-                "key": "Header2",
-                "value": "header2Example"
-              },
-              {
-                "key": "Header3",
-                "value": "header3Example"
-              }
-            ],
-            "method": "POST",
-            "body": {
-              "mode": "raw",
-              "raw": "{\"name\":\"Doe Enterprise\",\"value\":\"Silver\"}"
-            }
-          }
-        },
-        {
-          "response": [
+          "name": "{uriParam1}{uriParam2}",
+          "description": {
+            "content": "",
+            "type": "text/plain"
+          },
+          "item": [
             {
-              "header": [],
-              "cookie": [],
-              "code": "201",
-              "name": "201",
-              "body": "{\"name\":\"Software Corp\",\"address\":\"35 Central Street\"}"
+              "response": [],
+              "event": [],
+              "name": "/organization/:uriParam1:uriParam2",
+              "request": {
+                "url": {
+                  "path": [
+                    "organization",
+                    ":uriParam1:uriParam2"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [],
+                  "variables": [
+                    {
+                      "key": "uriParam1",
+                      "value": "",
+                      "description": ""
+                    },
+                    {
+                      "key": "uriParam2",
+                      "value": "example",
+                      "description": ""
+                    }
+                  ]
+                },
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Header1",
+                    "value": "2016-02-28T16:41:41.090Z",
+                    "disabled": true
+                  },
+                  {
+                    "key": "Header2",
+                    "value": "header2Example"
+                  },
+                  {
+                    "key": "Header3",
+                    "value": "header3Example"
+                  }
+                ],
+                "method": "POST",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\"name\":\"Doe Enterprise\",\"value\":\"Silver\"}"
+                }
+              }
+            },
+            {
+              "response": [
+                {
+                  "header": [],
+                  "cookie": [],
+                  "code": "201",
+                  "name": "201",
+                  "body": "{\"name\":\"Software Corp\",\"address\":\"35 Central Street\"}"
+                }
+              ],
+              "event": [],
+              "name": "/organization/:uriParam1:uriParam2",
+              "request": {
+                "url": {
+                  "path": [
+                    "organization",
+                    ":uriParam1:uriParam2"
+                  ],
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "query": [
+                    {
+                      "key": "param1",
+                      "value": "5"
+                    },
+                    {
+                      "key": "param2",
+                      "value": "param2Example"
+                    }
+                  ],
+                  "variables": [
+                    {
+                      "key": "uriParam1",
+                      "value": "",
+                      "description": ""
+                    },
+                    {
+                      "key": "uriParam2",
+                      "value": "example",
+                      "description": ""
+                    }
+                  ]
+                },
+                "method": "GET",
+                "description": "Returns an organization entity."
+              }
             }
           ],
-          "event": [],
-          "name": "/organization/:uriParam1:uriParam2",
-          "request": {
-            "url": {
-              "path": [
-                "organization",
-                ":uriParam1:uriParam2"
-              ],
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "query": [
-                {
-                  "key": "param1",
-                  "value": "5"
-                },
-                {
-                  "key": "param2",
-                  "value": "param2Example"
-                }
-              ],
-              "variables": [
-                {
-                  "key": "uriParam1",
-                  "value": "",
-                  "description": ""
-                },
-                {
-                  "key": "uriParam2",
-                  "value": "example",
-                  "description": ""
-                }
-              ]
-            },
-            "method": "GET",
-            "description": "Returns an organization entity."
-          }
+          "event": []
         }
       ],
-      "event": [],
-      "name": "/organization/{uriParam1}{uriParam2}"
+      "event": []
     }
   ],
   "event": [],
@@ -119,6 +133,6 @@
     "name": "Types raml API",
     "version": "",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "description": "# Description\n\n\n\n# Documentation\n\n"
+    "description": ""
   }
 }

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -122,10 +122,14 @@ describe('CONVERT FUNCTION TESTS ', function() {
       expect(collectionJSON).to.be.an('object');
 
       // types used in request (url, headers and body) of first item
-      expect(collectionJSON.item[0].item[0].request).to.deep.equal(collectionFixture.item[0].item[0].request);
+      expect(collectionJSON.item[0].item[0].item[0].request).to.deep.equal(
+        collectionFixture.item[0].item[0].item[0].request
+      );
 
       // types used in response body of second item
-      expect(collectionJSON.item[0].item[1].response).to.deep.equal(collectionFixture.item[0].item[1].response);
+      expect(collectionJSON.item[0].item[0].item[1].response).to.deep.equal(
+        collectionFixture.item[0].item[0].item[1].response
+      );
       done();
     });
   });
@@ -151,8 +155,8 @@ describe('CONVERT FUNCTION TESTS ', function() {
       expect(collectionJSON).to.be.an('object');
 
       // traits used in headers of a request
-      expect(collectionJSON.item[0].item[0].request.header).to.deep.equal(
-        collectionFixture.item[0].item[0].request.header
+      expect(collectionJSON.item[0].request.header).to.deep.equal(
+        collectionFixture.item[0].request.header
       );
       done();
     });

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -221,6 +221,30 @@ describe('CONVERT FUNCTION TESTS ', function() {
       done();
     });
   });
+
+  it('The converter should convert raml spec to postman collection ' +
+      'with proper folder structure', function(done) {
+    let collectionFixture = JSON.parse(fs.readFileSync(
+        VALID_RAML_DIR_PATH + '/ramlSpecFolderStructureCollection.json'
+      ).toString()),
+      collectionJSON;
+
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/ramlSpecFolderStructure.raml'
+    }, null, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+
+      collectionJSON = conversionResult.output[0].data;
+      removeId(collectionJSON);
+      expect(collectionJSON).to.be.an('object');
+      expect(collectionJSON).to.deep.equal(collectionFixture);
+      done();
+    });
+  });
 });
 
 /* Plugin Interface Tests */


### PR DESCRIPTION
In RAML we can specify resources as nested and as individual like in OpenAPI.

For this reason we need to merge resources with same prefix path under same folder. 

Also in RAML unlike OpenAPI, we can specify name and description of resource (Note that resource and method are different) so if resource has no methods but has name or description we will not collapse it with it’s parent folder for postman collection. 