### PR TITLE
Fixed default response body from object to null.

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -411,10 +411,11 @@ helper = {
     }
 
     _.forEach(responses, (res) => {
-      let responseBody = {},
+      let responseBody = null,
         responseHeaders = [],
         responseBodyType,
         contentHeader,
+        convertedResponse,
         previewLanguage = 'text';
 
       _.forEach(res.headers, (header) => {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -428,6 +428,11 @@ helper = {
         responseBody = this.getBodySchema(res.body[responseBodyType], types, options.exampleParametersResolution);
         contentHeader = { key: 'Content-Type', value: responseBodyType };
 
+        // postman collection expects null or string as valid response body, while request body to be object
+        if (_.isEmpty(responseBody)) {
+          responseBody = null;
+        }
+
         // set preview language (used in PM response body)
         if (responseBodyType === APP_JSON) {
           previewLanguage = PREVIEW_LANGUAGE.JSON;

--- a/test/unit/helper.test.js
+++ b/test/unit/helper.test.js
@@ -1,0 +1,21 @@
+var expect = require('chai').expect,
+  helper = require('../../lib/helper.js');
+
+describe('HELPER FUNCTION TESTS ', function() {
+  it('convertResponse function should return null body response as default', function(done) {
+    var convertedResponse = helper.convertResponse([
+      {
+        'body': {
+          '200': {
+            // a valid media type of body should be specified
+          }
+        }
+      }
+    ], {}, {}, {});
+
+    expect(convertedResponse).to.be.an('array');
+    expect(convertedResponse[0]).to.have.any.keys('name', 'code', 'header', 'body');
+    expect(convertedResponse[0].body).to.be.null;
+    done();
+  });
+});


### PR DESCRIPTION
Postman collection v2 expects response body to be null/string. As `getBodySchema()` function returns empty object by default, for response we have modified it so if empty object is returned than we will treat body as null.