### PR TITLE
Fixed type error "path must be string" when nonresolved includes are present.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -170,7 +170,7 @@ var converter = {
         content = browser ? fileDataResolver : fileResolver,
         ramlAPI = raml.parseRAMLSync(ramlString, {
           fsResolver: {
-            rootFilePath: files.rootFilePath,
+            rootFilePath: files.rootFilePath || '',
             allFilePaths: _.isArray(files.allFilePaths) ? _.map(files.allFilePaths, 'fileName') : [],
             content: content
           }

--- a/test/fixtures/valid-raml/unresolvedIncludes.raml
+++ b/test/fixtures/valid-raml/unresolvedIncludes.raml
@@ -1,0 +1,34 @@
+#%RAML 1.0
+
+title: User API
+version: 2.0
+baseUri: /api/users-api/{version}
+
+description: This API allows to query/modify and register users.
+
+types:
+  error-response: !include types/error-response/error-response.raml
+  create-user-request: !include types/create-user-request.raml
+  create-user-response: !include types/create-user-response.raml
+
+traits:
+  traceable: !include traits/traceability/traceability-headers.raml
+
+/users:
+  post:
+    is: [ traceable ]
+    description: Creates/registers a new user.
+    body:
+      application/json:
+        type: create-user-request
+    responses:
+      201:
+        description: Successfully created/registered the user.
+        body:
+          application/json:
+            type: create-user-response
+      409:
+        description: Duplicate user detected.
+        body:
+          application/json:
+            type: error-response

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -450,6 +450,19 @@ describe('CONVERT FUNCTION TESTS ', function() {
       done();
     });
   });
+
+  it('The converter should convert schema with non-referenced include statements', function (done) {
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/unresolvedIncludes.raml'
+    }, {}, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+      done();
+    });
+  });
 });
 
 /* Plugin Interface Tests */


### PR DESCRIPTION
This PR fixes issue where TypeError is thrown when unreferenced `!include` statements are present in schema.