### PR TITLE
Added support for resource types.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get Code
+        uses: actions/checkout@v3
+      - name: Setup Node JS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm run test

--- a/.npmignore
+++ b/.npmignore
@@ -156,6 +156,9 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
+# Remove GitHub actions related data
+.github
+
 ### Linux template
 *~
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -191,7 +191,8 @@ var converter = {
           baseUriParameters: ramlJSON.baseUriParameters,
           securitySchemes: '',
           securedBy: _.get(ramlJSON, 'securedBy', '')
-        };
+        },
+        resourceTypes = _.get(ramlJSON, 'resourceTypes', {});
 
       // Assign default options.
       options = overrideOptions(options);
@@ -216,6 +217,13 @@ var converter = {
         key: 'baseUrl',
         value: '{{baseUrl}}',
         type: 'string'
+      });
+
+      // Resolve resources by inheriting defined resource types
+      ramlJSON.resources && _.forEach(ramlJSON.resources, (resource) => {
+        let resolvedResource = helper.resolveResource(resource, resourceTypes);
+
+        resource = resolvedResource;
       });
 
       if (options.collapseFolders) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -220,11 +220,7 @@ var converter = {
       });
 
       // Resolve resources by inheriting defined resource types
-      ramlJSON.resources && _.forEach(ramlJSON.resources, (resource) => {
-        let resolvedResource = helper.resolveResource(resource, resourceTypes);
-
-        resource = resolvedResource;
-      });
+      ramlJSON.resources && (ramlJSON.resources = helper.resolveResources(ramlJSON.resources, resourceTypes));
 
       if (options.collapseFolders) {
         // creating a root node for the trie (serves as the root dir)

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1017,7 +1017,7 @@ helper = {
           inheritedResourceData;
 
         // All methods for resources are defined in methods attribute after parsing RAML
-        _.forEach(_.get(resolvedResource, 'methods'), (resourceMethod) => {
+        _.forEach(_.get(resolvedResource, 'methods'), (resourceMethod, index) => {
           let methodName = resourceMethod.method;
 
           if (_.has(inheritedResource, methodName)) {
@@ -1025,7 +1025,7 @@ helper = {
              * If method already exist then merge data by giving more preference to resource data
              * over inherited resource data via resource type
              */
-            resourceMethod = _.assign({}, inheritedResource[methodName], resourceMethod);
+            resolvedResource.methods[index] = _.assign({}, inheritedResource[methodName], resourceMethod);
             resolvedMethods.push(methodName);
           }
         });
@@ -1043,7 +1043,7 @@ helper = {
         // Inherit other properties like displayName, description, traits etc.
         inheritedResourceData = _.omit(inheritedResource, _.concat(['usage', 'name'], METHODS));
 
-        resolvedResource = _.assign({}, inheritedResourceData, resource);
+        resolvedResource = _.assign({}, inheritedResourceData, resolvedResource);
       }
     }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -998,56 +998,64 @@ helper = {
   /**
    * Resolves a resource by inheriting values from global resourceTypes as defined for corresponding resource
    *
-   * @param {*} resource - Resource to be resolved
+   * @param {*} resources - Resource to be resolved
    * @param {*} resourceTypes - Resource types defined at global level of RAML definition
    * @returns {*} - Resolved resource
    */
-  resolveResource: function (resource, resourceTypes) {
-    let resolvedResource = resource,
-      inheritedResource;
+  resolveResources: function (resources, resourceTypes) {
+    const resolveTypesMap = {};
 
-    if (resource && !_.isEmpty(resource.type)) {
-      inheritedResource = _.find(resourceTypes, (resourceType) => {
-        return _.has(resourceType, resource.type);
-      });
-      inheritedResource = _.get(inheritedResource, resource.type);
+    // calculate resource type map to be used for quick access further
+    _.forEach(resourceTypes, (resourceType, index) => {
+      let resolveTypeKey = _.head(_.keys(resourceType));
 
-      if (inheritedResource) {
-        let resolvedMethods = [],
-          inheritedResourceData;
+      resolveTypesMap[resolveTypeKey] = index;
+    });
 
-        // All methods for resources are defined in methods attribute after parsing RAML
-        _.forEach(_.get(resolvedResource, 'methods'), (resourceMethod, index) => {
-          let methodName = resourceMethod.method;
+    return _.map(resources, (resource) => {
+      let resolvedResource = resource,
+        inheritedResource;
 
-          if (_.has(inheritedResource, methodName)) {
-            /**
-             * If method already exist then merge data by giving more preference to resource data
-             * over inherited resource data via resource type
-             */
-            resolvedResource.methods[index] = _.assign({}, inheritedResource[methodName], resourceMethod);
-            resolvedMethods.push(methodName);
-          }
-        });
+      if (resource && !_.isEmpty(resource.type)) {
+        inheritedResource = _.get(resourceTypes, [resolveTypesMap[resource.type], resource.type]);
 
-        _.forEach(METHODS, (method) => {
-          if (_.has(inheritedResource, method) && !_.includes(resolvedMethods, method)) {
-            if (!resolvedResource.methods || !_.isArray(resolvedResource.methods)) {
-              resolvedResource.methods = [];
+        if (inheritedResource) {
+          let resolvedMethods = [],
+            inheritedResourceData;
+
+          // All methods for resources are defined in methods attribute after parsing RAML
+          _.forEach(_.get(resolvedResource, 'methods'), (resourceMethod, index) => {
+            let methodName = resourceMethod.method;
+
+            if (_.has(inheritedResource, methodName)) {
+              /**
+               * If method already exist then merge data by giving more preference to resource data
+               * over inherited resource data via resource type
+               */
+              resolvedResource.methods[index] = _.assign({}, inheritedResource[methodName], resourceMethod);
+              resolvedMethods.push(methodName);
             }
-            // Add methods present in resource type but not present for corresponding resource
-            resolvedResource.methods.push(inheritedResource[method]);
-          }
-        });
+          });
 
-        // Inherit other properties like displayName, description, traits etc.
-        inheritedResourceData = _.omit(inheritedResource, _.concat(['usage', 'name'], METHODS));
+          _.forEach(METHODS, (method) => {
+            if (_.has(inheritedResource, method) && !_.includes(resolvedMethods, method)) {
+              if (!resolvedResource.methods || !_.isArray(resolvedResource.methods)) {
+                resolvedResource.methods = [];
+              }
+              // Add methods present in resource type but not present for corresponding resource
+              resolvedResource.methods.push(inheritedResource[method]);
+            }
+          });
 
-        resolvedResource = _.assign({}, inheritedResourceData, resolvedResource);
+          // Inherit other properties like displayName, description, traits etc.
+          inheritedResourceData = _.omit(inheritedResource, _.concat(['usage', 'name'], METHODS));
+
+          resolvedResource = _.assign({}, inheritedResourceData, resolvedResource);
+        }
       }
-    }
 
-    return resolvedResource;
+      return resolvedResource;
+    });
   }
 };
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -27,7 +27,16 @@ const SDK = require('postman-collection'),
     maxItems: 2,
     useDefaultValue: true,
     ignoreMissingRefs: true
-  };
+  },
+  METHODS = [
+    'get',
+    'patch',
+    'put',
+    'post',
+    'delete',
+    'options',
+    'head'
+  ];
 
 var authTypeMap = {
     'Basic Authentication': 'basic',
@@ -984,6 +993,61 @@ helper = {
     });
 
     return null;
+  },
+
+  /**
+   * Resolves a resource by inheriting values from global resourceTypes as defined for corresponding resource
+   *
+   * @param {*} resource - Resource to be resolved
+   * @param {*} resourceTypes - Resource types defined at global level of RAML definition
+   * @returns {*} - Resolved resource
+   */
+  resolveResource: function (resource, resourceTypes) {
+    let resolvedResource = resource,
+      inheritedResource;
+
+    if (resource && !_.isEmpty(resource.type)) {
+      inheritedResource = _.find(resourceTypes, (resourceType) => {
+        return _.has(resourceType, resource.type);
+      });
+      inheritedResource = _.get(inheritedResource, resource.type);
+
+      if (inheritedResource) {
+        let resolvedMethods = [],
+          inheritedResourceData;
+
+        // All methods for resources are defined in methods attribute after parsing RAML
+        _.forEach(_.get(resolvedResource, 'methods'), (resourceMethod) => {
+          let methodName = resourceMethod.method;
+
+          if (_.has(inheritedResource, methodName)) {
+            /**
+             * If method already exist then merge data by giving more preference to resource data
+             * over inherited resource data via resource type
+             */
+            resourceMethod = _.assign({}, inheritedResource[methodName], resourceMethod);
+            resolvedMethods.push(methodName);
+          }
+        });
+
+        _.forEach(METHODS, (method) => {
+          if (_.has(inheritedResource, method) && !_.includes(resolvedMethods, method)) {
+            if (!resolvedResource.methods || !_.isArray(resolvedResource.methods)) {
+              resolvedResource.methods = [];
+            }
+            // Add methods present in resource type but not present for corresponding resource
+            resolvedResource.methods.push(inheritedResource[method]);
+          }
+        });
+
+        // Inherit other properties like displayName, description, traits etc.
+        inheritedResourceData = _.omit(inheritedResource, _.concat(['usage', 'name'], METHODS));
+
+        resolvedResource = _.assign({}, inheritedResourceData, resource);
+      }
+    }
+
+    return resolvedResource;
   }
 };
 

--- a/test/fixtures/valid-raml/resourceTypes.raml
+++ b/test/fixtures/valid-raml/resourceTypes.raml
@@ -1,0 +1,29 @@
+#%RAML 1.0
+title: Example API
+
+resourceTypes:
+  collection:
+    usage: This resourceType should be used for any collection of items
+    description: The collection of <<resourcePathName>>
+    get:
+      description: Get all <<resourcePathName>>, optionally filtered
+      responses:
+        200:
+          body:
+            application/json:
+              properties:
+                groupName:
+                  default: groupName example
+                deptCode:
+                  type: number
+                  default: 12345
+          headers:
+            Location:
+              example: /invoices/45612
+            Header:
+              example: Bangalore
+    post:
+      description: Create a new <<resourcePathName | !singularize>>
+
+/products:
+  type: collection

--- a/test/fixtures/valid-raml/resourceTypesConflict.raml
+++ b/test/fixtures/valid-raml/resourceTypesConflict.raml
@@ -1,0 +1,37 @@
+#%RAML 1.0
+title: Example API
+
+resourceTypes:
+  collection:
+    usage: This resourceType should be used for any collection of items
+    description: The collection of <<resourcePathName>>
+    get:
+      description: Get all <<resourcePathName>>, optionally filtered
+      responses:
+        200:
+          body:
+            application/json:
+              properties:
+                groupName:
+                  default: groupName example
+                deptCode:
+                  type: number
+                  default: 12345
+          headers:
+            Location:
+              example: /invoices/45612
+            Header:
+              example: Bangalore
+    post:
+      description: Create a new <<resourcePathName | !singularize>>
+      headers:
+        UserID:
+          description: the identifier for the user who posts a new organization
+          type: string
+          example: SWED-123 # single scalar example
+
+/products:
+  displayName: Products related operations
+  type: collection
+  post:
+    description: Create new Essential Product

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -493,6 +493,45 @@ describe('CONVERT FUNCTION TESTS ', function() {
       done();
     });
   });
+
+  it('The converter should convert schema with resourceTypes correctly by inheriting data correctly', function (done) {
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/resourceTypesConflict.raml'
+    }, {}, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+
+      collectionJSON = conversionResult.output[0].data;
+      removeId(collectionJSON);
+      expect(collectionJSON).to.be.an('object');
+
+      // should inherit resource type data other than methods as well
+      expect(collectionJSON.item[0].name).to.eql('Products related operations');
+
+      // types used in request (headers and body) of first item
+      expect(collectionJSON.item[0].item).to.have.lengthOf(2);
+
+      expect(collectionJSON.item[0].item[0].name).to.eql('/products');
+      expect(collectionJSON.item[0].item[0].request.method).to.eql('POST');
+
+      // Description should be same as mentioned in resource even though defined in resource type
+      expect(collectionJSON.item[0].item[0].request.description).to.eql('Create new Essential Product');
+      expect(collectionJSON.item[0].item[0].request.header).to.have.lengthOf(1);
+      expect(collectionJSON.item[0].item[0].request.header[0].key).to.eql('UserID');
+      expect(collectionJSON.item[0].item[0].response).to.have.lengthOf(0);
+
+      expect(collectionJSON.item[0].item[1].name).to.eql('/products');
+      expect(collectionJSON.item[0].item[1].request.method).to.eql('GET');
+      expect(collectionJSON.item[0].item[1].response).to.have.lengthOf(1);
+      expect(collectionJSON.item[0].item[1].response[0].code).to.eql(200);
+      expect(collectionJSON.item[0].item[1].response[0].header).to.have.lengthOf(3);
+      expect(collectionJSON.item[0].item[1].response[0].body).to.be.not.empty;
+      done();
+    });
+  });
 });
 
 /* Plugin Interface Tests */

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -463,6 +463,36 @@ describe('CONVERT FUNCTION TESTS ', function() {
       done();
     });
   });
+
+  it('The converter should convert schema with resourceTypes defined correctly', function (done) {
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/resourceTypes.raml'
+    }, {}, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+
+      collectionJSON = conversionResult.output[0].data;
+      removeId(collectionJSON);
+      expect(collectionJSON).to.be.an('object');
+
+      // types used in request (headers and body) of first item
+      expect(collectionJSON.item[0].item).to.have.lengthOf(2);
+      expect(collectionJSON.item[0].item[0].name).to.eql('/products');
+      expect(collectionJSON.item[0].item[0].request.method).to.eql('GET');
+      expect(collectionJSON.item[0].item[0].response).to.have.lengthOf(1);
+      expect(collectionJSON.item[0].item[0].response[0].code).to.eql(200);
+      expect(collectionJSON.item[0].item[0].response[0].header).to.have.lengthOf(3);
+      expect(collectionJSON.item[0].item[0].response[0].body).to.be.not.empty;
+
+      expect(collectionJSON.item[0].item[1].name).to.eql('/products');
+      expect(collectionJSON.item[0].item[1].request.method).to.eql('POST');
+      expect(collectionJSON.item[0].item[1].response).to.have.lengthOf(0);
+      done();
+    });
+  });
 });
 
 /* Plugin Interface Tests */


### PR DESCRIPTION
Fixes: https://github.com/postmanlabs/postman-app-support/issues/9415

### Overview:
This PR adds support for [resourceTypes](https://github.com/postmanlabs/postman-app-support/issues/link). We'll be inheriting resource type if defined for the corresponding resource via mentioning it in `type`.

While inheriting the data, we'll be making sure that for conflicting data that's present in both the resource and mentioned resource type, resource value will be picked up.