### PR TITLE
Fix an error where conversion failed if securitySchemes are not defined

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 
 jobs:
   Unit-Tests:

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -565,7 +565,8 @@ helper = {
 
     // map RAML schema security schema and PM request auths. set null by default.
     auth.type = _.get(authTypeMap, _.get(securitySchemes[securedBy], 'type'), null);
-    _.has(securitySchemes[securedBy], 'description') && (auth.describe(securitySchemes[securedBy].description));
+    typeof _.get(securitySchemes, `[${securedBy}].description`) === 'string' &&
+      (auth.describe(securitySchemes[securedBy].description));
 
     return auth;
   },

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -565,7 +565,7 @@ helper = {
 
     // map RAML schema security schema and PM request auths. set null by default.
     auth.type = _.get(authTypeMap, _.get(securitySchemes[securedBy], 'type'), null);
-    securitySchemes[securedBy].description && (auth.describe(securitySchemes[securedBy].description));
+    _.has(securitySchemes[securedBy], 'description') && (auth.describe(securitySchemes[securedBy].description));
 
     return auth;
   },
@@ -658,7 +658,8 @@ helper = {
     request.body = pmRequestBody.body;
     request.addHeader(pmRequestBody.contentHeader);
 
-    securedBy && (request.auth = helper.convertSecurityScheme(securedBy[0], globalParameters.securitySchemes));
+    !_.isEmpty(securedBy) && !_.isEmpty(globalParameters.securitySchemes) &&
+      (request.auth = helper.convertSecurityScheme(securedBy[0], globalParameters.securitySchemes));
 
     request.url = requestUrl;
     request.method = _.toUpper(method.method);

--- a/test/fixtures/valid-raml/unresolvedSecuritySchemes.raml
+++ b/test/fixtures/valid-raml/unresolvedSecuritySchemes.raml
@@ -1,0 +1,40 @@
+#%RAML 1.0
+title: Unresolved SecuritySchemes
+mediaType: application/json
+description: This is a simple raml API where resources point to missing securitySchemes.
+version: v3
+baseUri: https://api.BasicRamlAPI.com/{version}
+securedBy: basic
+/users:
+  /search:
+    get:
+      responses:
+          201:
+            body:
+              application/json:
+                properties:
+                  groupName:
+                    default: groupName example
+                  deptCode:
+                    type: number
+                    default: 12345
+            headers:
+              Location:
+                example: /invoices/45612
+              Header:
+                example: Bangalore
+    post:
+      body:
+        properties:
+          firstname: string
+          lastname: string
+          age: number
+        example:
+          firstname: someName
+          lastname: someLastName
+          age: 10
+      headers:
+        myHeader:
+          example: headerExample
+        SomeOtherHeader:
+          example: OtherExample

--- a/test/unit/base.test.js
+++ b/test/unit/base.test.js
@@ -532,6 +532,33 @@ describe('CONVERT FUNCTION TESTS ', function() {
       done();
     });
   });
+
+  it('should convert schema with with unresolved securitySchemes', function (done) {
+    Converter.convert({
+      type: 'file',
+      data: VALID_RAML_DIR_PATH + '/unresolvedSecuritySchemes.raml'
+    }, {}, (err, conversionResult) => {
+      expect(err).to.be.null;
+      expect(conversionResult.result).to.equal(true);
+      expect(conversionResult.output.length).to.equal(1);
+      expect(conversionResult.output[0].type).to.equal('collection');
+
+      collectionJSON = conversionResult.output[0].data;
+      removeId(collectionJSON);
+      expect(collectionJSON).to.be.an('object');
+
+      // Check if valid number of request exist
+      expect(collectionJSON.item[0]).to.have.property('item').an('array').length(2);
+
+      // Request should not have auth defined
+      expect(collectionJSON.item[0].item[0]).to.have.property('request');
+      expect(collectionJSON.item[0].item[0].request).to.not.have.property('auth');
+
+      expect(collectionJSON.item[0].item[1]).to.have.property('request');
+      expect(collectionJSON.item[0].item[1].request).to.not.have.property('auth');
+      done();
+    });
+  });
 });
 
 /* Plugin Interface Tests */


### PR DESCRIPTION
## Overview
This PR fixes an issue when RAML contains `securitySchemes` that could not be resolved.

## RCA
When the spec did not have any securitySchemes but an existing resource references it via the `securedBy` parameter, it was throwing a referencing error as it was trying to do `securitySchemes[securedBy].description`, but since `securitySchemes` was an empty string, `securitySchemes[securedBy]` was `undefined`, leading to this error. This used to happen when creating auth object for the collection request.

## Fix
- Only resolve auth object for collection when both `securedBy` and `securitySchemes` are not empty
- Even if both are non-empty, verify the existence of the `description` key via a safe check

Additional change - Test action runs only once for a PR. It runs on `push` only for the `master` and `develop` branches.