### PR TITLE
Releases using GitHub Actions

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -4,16 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: The version you want to release
+        description: The version you want to release. Must be a valid semver version.
         required: true
+        type: string
 
 jobs:
   draft-new-release:
+    if: startsWith(github.event.inputs.version, 'v')
     name: Draft a new release
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -44,13 +47,28 @@ jobs:
       - name: Push new branch
         run: git push origin release/${{ github.event.inputs.version }}
 
-      - name: Create pull request
+      - name: Create pull request for master
         uses: thomaseizinger/create-pull-request@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           head: release/${{ github.event.inputs.version }}
           base: master
+          title: "Release version ${{ github.event.inputs.version }}"
+          reviewers: ${{ github.actor }}
+          body: |
+            Hi @${{ github.actor }}!
+
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+
+      - name: Create pull request for develop
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: develop
           title: "Release version ${{ github.event.inputs.version }}"
           reviewers: ${{ github.actor }}
           body: |

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,60 @@
+name: Draft new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version you want to release
+        required: true
+
+jobs:
+  draft-new-release:
+    name: Draft a new release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Bump version
+        run: npm version ${{ github.event.inputs.version }} --git-tag-version false
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          git add CHANGELOG.md package.json package-lock.json
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+      
+      - name: Push new branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: master
+          title: "Release version ${{ github.event.inputs.version }}"
+          reviewers: ${{ github.actor }}
+          body: |
+            Hi @${{ github.actor }}!
+
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -16,7 +16,6 @@ jobs:
       (contains(github.event.pull_request.head.ref, 'release/') || contains(github.event.pull_request.head.ref, 'hotfix/'))
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - name: Extract version from branch name (for release branches)
@@ -45,15 +44,3 @@ jobs:
           name: ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: false
-
-      - name: Merge master into develop branch
-        uses: thomaseizinger/create-pull-request@1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          head: master
-          base: develop
-          title: Merge master into develop branch
-          body: |
-            This PR merges the master branch back into develop.
-            This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates are also present on the develop branch.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -1,0 +1,59 @@
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish new release
+    runs-on: ubuntu-latest
+    # only merged pull requests that begin with 'release/' or 'hotfix/' must trigger this job
+    if: github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.head.ref, 'release/') || contains(github.event.pull_request.head.ref, 'hotfix/'))
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: contains(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from branch name (for hotfix branches)
+        if: contains(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create Release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+
+      - name: Merge master into develop branch
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: master
+          base: develop
+          title: Merge master into develop branch
+          body: |
+            This PR merges the master branch back into develop.
+            This happens to ensure that the updates that happened on the release branch, i.e. CHANGELOG and manifest updates are also present on the develop branch.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,22 +2,21 @@ name: Test
 
 on:
   push:
-    branches:
-      - develop
-      - master
+    branches: [develop, master]
   pull_request:
 
 jobs:
   Unit-Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 16.x, 18.x]
     steps:
       - name: Get Code
         uses: actions/checkout@v3
-      - name: Setup Node JS
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
-      - name: Install dependencies
-        run: npm install
-      - name: Run tests
-        run: npm run test
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # RAML 1.0 to Postman Changelog
 
+## [Unreleased]
+
+### Added
+
+-   GitHub Actions for Release management.
+
+### Changed
+
+-   Bumped up minimum Node version to 12.
+-   Unit tests now run on Node versions 12, 16 and 18.
+
+### Fixed
+
+-   Fixed an issue where conversion failed if securitySchemes are not resolved.
+
+## Previous Releases
+Newer releases follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 #### v0.1.7 (March 17, 2023)
 * Added support for resource types.
 
@@ -26,3 +43,5 @@
 
 #### v0.0.1 (November 28, 2019)
 * Base release
+
+[Unreleased]: https://github.com/postmanlabs/raml1-to-postman/compare/0.1.7...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to @postmanlabs/read-sso-cookie
+# Contributing to @postmanlabs/raml1-to-postman
 
 ## tl;dr
 
@@ -16,6 +16,7 @@ npm test
 ```
 
 - If all checks out, push your code and create a pull with `develop` as the target
+- Add a small note on what's changed in `CHANGELOG.md` under `Unreleased` section
 
 ```bash
 git push feature/my-feature
@@ -27,26 +28,7 @@ This repository uses standard `git-flow` branch management policy/strategy. If y
 
 
 ## Preferred IDE
-The preferred IDE for this project is SublimeText. You can download it from [http://www.sublimetext.com](http://www.sublimetext.com).
-
-The repository has a sublime project file included in `develop/` directory. This project is configured with the best practices recommended for `xt-edge`. Things like using 120 character ruler, addition of end-of-file newline, cleaning up of trailing whitespace has been configured in this project.
-
-There are a number of SublimeText Plugins that you can use to make your life simpler. One of them is the `jsDoc` autocompletion plugin. Download it from [https://github.com/spadgos/sublime-jsdocs](https://github.com/spadgos/sublime-jsdocs).
-
-> *It is expected that changes to the file `/postman-documentator.sublime-project` is not committed back in the repository without proper discussion with all primary contributors of this project.*
-
-### Generic IDE Settings
-
-Most IDE settings for Sublime Text resides within the project configuration file `./develop/xt-edge.sublime-project`. In case you are using any other IDE, (not recommended,) setting the following defaults of the IDE should help.
-
-1. Set to true to ensure the last line of the file ends in a newline character when saving.
-2. Use 120the columns to display vertical ruler.
-3. The number of spaces a tab is considered equal should be 4.
-4. Insert spaces when tab is pressed.
-5. Remove trailing white space on save.
-6. Always use UTF-8 character encoding for reading and writing files.
-7. Set IDE to not change file permissions upon editing.
-
+The preferred IDE for this project is [VSCode](https://code.visualstudio.com/).
 
 ## Commit Guidelines
 
@@ -88,9 +70,9 @@ The third is the most important question to answer, as it can point out problems
 A good commit message template
 
 ```
-Short (50 chars or less) summary of changes with relevant project management issue ID.
+Short (50 chars or less) summary of changes with relevant issue link.
 
-More detailed explanatory text, if necessary.  Wrap it to about 72 characters or so.  In some contexts, the first line is treated as the subject of an email and the rest of the text as the body.  The blank line separating the summary from the body is critical (unless you omit the body entirely); tools like rebase can get confused if you run the two together.
+More detailed explanatory text, if necessary. Wrap it to about 72 characters or so. In some contexts, the first line is treated as the subject of an email and the rest of the text as the body. The blank line separating the summary from the body is critical (unless you omit the body entirely); tools like rebase can get confused if you run the two together.
 
 Further paragraphs come after blank lines.
 
@@ -100,16 +82,6 @@ Further paragraphs come after blank lines.
 ```
 
 Run `git log --no-merges` to see what a nicely formatted project-commit history looks like.
-
-## Documentation guidelines
-
-~~ to be documented further ~~
-
-## The CI Platform
-
-The CI system is built as a bunch of bash scripts to execute a set of tasks. These scripts are meant to execute tasks that can run on every local machine. In general, knowledge about these scripts are not necessary for development.
-
-**The scripts are to be only accessed using `npm run-script script name`.** This ensures that the execution point of the scripts (`pwd`) is always the repository root.
 
 ### Ensuring your commits will not fail build
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Automated the Release management process for GitFlow process using steps mentioned in [this blog](https://blog.eizinger.io/12274/using-github-actions-and-gitflow-to-automate-your-release-process).

### Changes
- Unit tests: Now run on NodeJS versions 12, 16 and 18.
- Bumped up minimum NodeJS version to 12.
- For automation to work the `CHANGELOG.md` file has to match the [Keep A Changelog](https://keepachangelog.com) format. 
- `draft-new-release`: This action is triggered manually. It creates a release branch, bumps up versions in `package.json` and `package-lock.json` and automatically inserts the latest tag in `CHANGELOG.md` file. Then creates PRs against `master` and `develop` branches. It requires write access to `contents` and `pull_requests` permissions, which has been done at the job level. This action can be triggered only by people with write access to the repository.
- `publish-new-release`: This action is triggered when PR from `release/` or `hotfix/` is merged into `master` branch. It will create a release and tag the commit in master. Additionally we can use this to automatically publish to NPM in the future, but because that action is irreversible, I've avoided it now and we can consider it in the future if required.

With the new changelog format, we now maintain an `Unreleased` section that will keep the list of all changes that are not yet released. The automation will insert the correct tag and create the links when drafting a new release. One advantage with this process is that we can keep adding to the `CHANGELOG.md` file in the PR to `develop`.

These flows have been tested on [my fork](https://github.com/dhwaneetbhatt/raml1-to-postman).

### What's Pending
Hotfix creation is not automated yet because we do not see a lot of hotfixes on the modules. We can take it up in the future if required. Until then we can live with a playbook.