### PR TITLE
Updated "postman-collection" usage to be specific to part of module being used.

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -2,7 +2,8 @@ const raml = require('./../assets/raml-1-parser'),
   _ = require('lodash'),
   fs = require('fs'),
   path = require('path-browserify'),
-  SDK = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
+  { Variable } = require('postman-collection/lib/collection/variable'),
   helper = require('./helper.js'),
   getOptions = require('./options').getOptions,
   { Node, Trie } = require('./trie.js'),
@@ -167,7 +168,7 @@ var converter = {
         }
       }
 
-      let collection = new SDK.Collection(),
+      let collection = new Collection(),
         content = browser ? fileDataResolver : fileResolver,
         ramlAPI,
         ramlJSON,
@@ -226,7 +227,7 @@ var converter = {
       });
 
       // convrtedBaseUrl is URL containing baseUrl in form of PM collection variable
-      convertedBaseUrl = new SDK.Variable({
+      convertedBaseUrl = new Variable({
         key: 'baseUrl',
         value: '{{baseUrl}}',
         type: 'string'

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,5 +1,15 @@
-const SDK = require('postman-collection'),
-  _ = require('lodash'),
+const _ = require('lodash'),
+  { QueryParam } = require('postman-collection/lib/collection/query-param'),
+  { Header } = require('postman-collection/lib/collection/header'),
+  { ItemGroup } = require('postman-collection/lib/collection/item-group'),
+  { Item } = require('postman-collection/lib/collection/item'),
+  { FormParam } = require('postman-collection/lib/collection/form-param'),
+  { RequestAuth } = require('postman-collection/lib/collection/request-auth'),
+  { Request } = require('postman-collection/lib/collection/request.js'),
+  { Response } = require('postman-collection/lib/collection/response'),
+  { RequestBody } = require('postman-collection/lib/collection/request-body'),
+  { Url } = require('postman-collection/lib/collection/url'),
+  { Variable } = require('postman-collection/lib/collection/variable'),
   schemaFaker = require('../assets/json-schema-faker.js'),
   resolver = require('./resolver.js'),
   Node = require('./trie.js').Node,
@@ -193,7 +203,7 @@ helper = {
   * @returns {Object} convertedHeader - postman sdk header object
   */
   convertHeader: function(header, types, resolveTo) {
-    let convertedHeader = new SDK.Header(),
+    let convertedHeader = new Header(),
       fakedHeader = safeSchemaFaker(header, types, resolveTo);
 
     convertedHeader.key = header.name;
@@ -273,7 +283,7 @@ helper = {
       param,
       paramArray = [],
       updateOptions = {},
-      reqBody = new SDK.RequestBody(),
+      reqBody = new RequestBody(),
       contentHeader,
       rDataMode,
       cType;
@@ -293,7 +303,7 @@ helper = {
 
       // create query parameters and add it to the request body object
       _.forOwn(bodyData, (value, key) => {
-        param = new SDK.QueryParam({
+        param = new QueryParam({
           key: key,
           value: (typeof value === 'object' ? JSON.stringify(value) : value)
         });
@@ -306,7 +316,7 @@ helper = {
       };
 
       // add a content type header for each media type for the request body
-      contentHeader = new SDK.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: URLENCODED
       });
@@ -320,7 +330,7 @@ helper = {
 
       // create the form parameters and add it to the request body object
       _.forOwn(bodyData, (value, key) => {
-        param = new SDK.FormParam({
+        param = new FormParam({
           key: key,
           value: (typeof value === 'object' ? JSON.stringify(value) : value)
         });
@@ -332,7 +342,7 @@ helper = {
         formdata: paramArray
       };
       // add a content type header for the pertaining media type
-      contentHeader = new SDK.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: FORM_DATA
       });
@@ -387,7 +397,7 @@ helper = {
         }
       };
 
-      contentHeader = new SDK.Header({
+      contentHeader = new Header({
         key: 'Content-Type',
         value: bodyType
       });
@@ -463,7 +473,7 @@ helper = {
         responseHeaders.push(contentHeader);
       }
 
-      convertedResponse = new SDK.Response({
+      convertedResponse = new Response({
         name: res.name || res.code,
         code: res.code ? Number(res.code) : 500,
         header: responseHeaders,
@@ -561,7 +571,7 @@ helper = {
   * @returns {Object} auth - postman sdk RequestAuth object
   */
   convertSecurityScheme: function(securedBy, securitySchemes) {
-    let auth = new SDK.RequestAuth();
+    let auth = new RequestAuth();
 
     // map RAML schema security schema and PM request auths. set null by default.
     auth.type = _.get(authTypeMap, _.get(securitySchemes[securedBy], 'type'), null);
@@ -588,14 +598,14 @@ helper = {
       _.forOwn(variablesToAdd, (value, key) => {
         // 'version' is reserved base URI parameter for RAML 1.0, value of it recieved in enum so special handling
         if (key === 'version') {
-          variables.push(new SDK.Variable({
+          variables.push(new Variable({
             id: key,
             value: _.get(value, 'enum[0]', ''),
             description: value.description || 'This is version of API schema.'
           }));
         }
         else {
-          variables.push(new SDK.Variable({
+          variables.push(new Variable({
             id: key,
             value: value.default || _.get(value.enum, '[0]') || '',
             description: value.description + (value.enum ? ' (is one of ' + value.enum + ')' : '')
@@ -606,7 +616,7 @@ helper = {
       });
     }
     if (keyName) {
-      variables.push(new SDK.Variable({
+      variables.push(new Variable({
         id: keyName,
         value: convertedBaseUrl,
         type: 'string'
@@ -629,8 +639,8 @@ helper = {
   * @returns {Object} request - postman sdk request object
   */
   convertToPmRequest: function(method, url, globalParameters, options, pathVariables) {
-    let request = new SDK.Request(),
-      requestUrl = new SDK.Url(),
+    let request = new Request(),
+      requestUrl = new Url(),
       securedBy = method.securedBy || globalParameters.securedBy,
       pmRequestBody;
 
@@ -684,7 +694,7 @@ helper = {
   * @returns {Object} item - postman sdk item object
   */
   convertRequestToItem: function (method, url, globalParameters, options, pathVariables) {
-    let item = new SDK.Item(),
+    let item = new Item(),
       requestName = _.get(method, 'displayName', url.replace('{{baseUrl}}', '')),
       pmRequest = helper.convertToPmRequest(method, url, globalParameters, options, pathVariables),
       optionsForResponse;
@@ -758,7 +768,7 @@ helper = {
   * @returns {Object} folder - postman sdk ItemGroup object
   */
   convertResources: function(baseUrl, res, globalParameters, options, pathVariables = []) {
-    var folder = new SDK.ItemGroup(),
+    var folder = new ItemGroup(),
       url,
       // used to store url after path variables of url is resolved
       convertedBaseUrl = _.cloneDeepWith(baseUrl),
@@ -845,7 +855,7 @@ helper = {
     if (resource.requestCount > 1 || !resource.collapsible) {
       // only return a Postman folder if this folder has>1 children in its subtree or it's not collapsible
       // otherwise we can end up with 10 levels of unwanted folders with 1 request in the end
-      itemGroup = new SDK.ItemGroup({
+      itemGroup = new ItemGroup({
         name: displayName === relativeUrl ? resource.name : displayName,
         description: _.get(resource, 'resourceInfo.description', '')
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async": "3.2.5",
         "lodash": "4.17.21",
         "path-browserify": "1.0.1",
-        "postman-collection": "4.2.1"
+        "postman-collection": "^4.4.0"
       },
       "devDependencies": {
         "chai": "4.1.2",
@@ -2215,9 +2215,9 @@
       }
     },
     "node_modules/postman-collection": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
-      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "dependencies": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",
@@ -4771,9 +4771,9 @@
       "dev": true
     },
     "postman-collection": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.2.1.tgz",
-      "integrity": "sha512-DFLt3/yu8+ldtOTIzmBUctoupKJBOVK4NZO0t68K2lIir9smQg7OdQTBjOXYy+PDh7u0pSDvD66tm93eBHEPHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.4.0.tgz",
+      "integrity": "sha512-2BGDFcUwlK08CqZFUlIC8kwRJueVzPjZnnokWPtJCd9f2J06HBQpGL7t2P1Ud1NEsK9NHq9wdipUhWLOPj5s/Q==",
       "requires": {
         "@faker-js/faker": "5.5.3",
         "file-type": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "async": "3.2.5",
     "lodash": "4.17.21",
     "path-browserify": "1.0.1",
-    "postman-collection": "4.2.1"
+    "postman-collection": "^4.4.0"
   },
   "devDependencies": {
     "chai": "4.1.2",

--- a/test/system/repository.test.js
+++ b/test/system/repository.test.js
@@ -44,12 +44,10 @@ describe('project repository', function () {
         expect(json.dependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        for (let item in json.dependencies) {
-          expect(json.dependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-          // eslint-disable-next-line max-len
-            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$|^git\+.*.+$'));
-        }
+      it('should have a valid version string in form of <major>.<minor>.<revision>', function () {
+        expect(json.version)
+          // eslint-disable-next-line max-len, security/detect-unsafe-regex
+          .to.match(/^((\d+)\.(\d+)\.(\d+))(?:-([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?(?:\+([\dA-Za-z-]+(?:\.[\dA-Za-z-]+)*))?$/);
       });
     });
 
@@ -58,12 +56,12 @@ describe('project repository', function () {
         expect(json.devDependencies).to.be.a('object');
       });
 
-      it('must point to a valid and precise (no * or ^) semver', function () {
-        for (let item in json.devDependencies) {
-          expect(json.devDependencies[item]).to.match(new RegExp('^((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
-          // eslint-disable-next-line max-len
-            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$|^git\+.*.+$'));
-        }
+      it('should point to a valid semver', function () {
+        Object.keys(json.devDependencies).forEach(function (dependencyName) {
+          // eslint-disable-next-line security/detect-non-literal-regexp
+          expect(json.devDependencies[dependencyName]).to.match(new RegExp('((\\d+)\\.(\\d+)\\.(\\d+))(?:-' +
+            '([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?(?:\\+([\\dA-Za-z\\-]+(?:\\.[\\dA-Za-z\\-]+)*))?$'));
+        });
       });
     });
 

--- a/test/unit/converter.test.js
+++ b/test/unit/converter.test.js
@@ -2,7 +2,8 @@ const expect = require('chai').expect,
   fs = require('fs'),
   converter = require('../../index'),
   helper = require('./../../lib/helper.js'),
-  SDK = require('postman-collection'),
+  { Collection } = require('postman-collection/lib/collection/collection'),
+  { Header } = require('postman-collection/lib/collection/header'),
   VALID_RAML_DIR_PATH = './test/fixtures/valid-raml',
   INVALID_VERSION_PATH = './test/fixtures/invalid-raml/invalidVersion.raml';
 
@@ -126,7 +127,7 @@ describe('helper functions', function() {
         description: 'This is the description.',
         version: '1.1'
       },
-      collection = new SDK.Collection(),
+      collection = new Collection(),
       modified_collection = helper.setCollectionInfo(info, collection);
 
     expect(modified_collection.name).to.equal('My sample api');
@@ -252,7 +253,7 @@ describe('helper functions', function() {
       types = {},
       postmanHeader = helper.convertHeader(ramlHeader, types, 'schema');
 
-    expect(SDK.Header.isHeader(postmanHeader)).to.be.true;
+    expect(Header.isHeader(postmanHeader)).to.be.true;
     expect(postmanHeader.disabled).to.be.true;
   });
 


### PR DESCRIPTION
## Overview

This PR updates "postman-collection" version used to latest. We're also now making sure that we're only requiring the part of SDK that's used in codebase by requiring specific files.


This means if we use say `Response` from `postman-collection` module then instead of requiring it like below,

```
const { Response } = require('postman-collection');
```

we will be requiring Response from specific module exporting it like below.

```
const { Response } = require('postman-collection/lib/collection/response');
```